### PR TITLE
fix(web): Fix the common-js module path

### DIFF
--- a/packages/canvas-tokens-web/package.json
+++ b/packages/canvas-tokens-web/package.json
@@ -4,7 +4,7 @@
   "description": "Canvas design tokens for web",
   "author": "Workday, Inc. (https://www.workday.com)",
   "license": "CC-BY-ND-4.0",
-  "main": "dist/commonjs/index.js",
+  "main": "dist/common-js/index.js",
   "module": "dist/es6/index.js",
   "sideEffects": false,
   "types": "dist/es6/index.d.ts",


### PR DESCRIPTION
## Issue

Fixes #19

## Overview

Jest tests do not work because Jest uses commonjs module resolution. The `package.json` references `"commonjs"` while the directory is `"common-js"`
