### PR TITLE
feat(web): Make type definitions of objects static

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10122,7 +10122,7 @@
     },
     "packages/canvas-tokens-web": {
       "name": "@workday/canvas-tokens-web",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "CC-BY-ND-4.0"
     }
   }

--- a/packages/canvas-tokens/build.ts
+++ b/packages/canvas-tokens/build.ts
@@ -64,7 +64,7 @@ const config = setConfig({
           level: ['brand', 'sys'],
           extensions: ['d.ts'],
           format: 'merge/types',
-          combineWith: ['merge/objects', '{platform}/objects'],
+          combineWith: ['merge/objects', '{platform}/types'],
         },
         {
           level: ['base'],

--- a/packages/canvas-tokens/utils/formatters/formatJS.ts
+++ b/packages/canvas-tokens/utils/formatters/formatJS.ts
@@ -46,6 +46,19 @@ export const formatES6ToObjects: Formatter = ({dictionary, file}) => {
 };
 
 /**
+ * Style Dictionary format function that create token type definitions.
+ * @param {*} FormatterArguments - Style Dictionary formatter object containing `dictionary`, `options`, `file` and `platform` properties.
+ * @returns file content as a string
+ */
+export const formatES6ToTypes: Formatter = ({dictionary, file}) => {
+  const headerContent = formatHelpers.fileHeader({file});
+  return Object.entries(dictionary.properties).reduce((acc: string, [key, values]) => {
+    return (acc +=
+      `export declare const ${key} = ` + JSON.stringify(values, null, 2) + ' as const;\n');
+  }, headerContent);
+};
+
+/**
  * Style Dictionary format function that create the export index file for es6 folder.
  * @param {*} FormatterArguments - Style Dictionary formatter object containing `dictionary`, `options`, `file` and `platform` properties.
  * @returns file content as a string

--- a/packages/canvas-tokens/utils/formatters/formatJS.ts
+++ b/packages/canvas-tokens/utils/formatters/formatJS.ts
@@ -54,7 +54,7 @@ export const formatES6ToTypes: Formatter = ({dictionary, file}) => {
   const headerContent = formatHelpers.fileHeader({file});
   return Object.entries(dictionary.properties).reduce((acc: string, [key, values]) => {
     return (acc +=
-      `export declare const ${key} = ` + JSON.stringify(values, null, 2) + ' as const;\n');
+      `export declare const ${key} = ` + JSON.stringify(values, null, 2) + ' as const;\n\n');
   }, headerContent);
 };
 

--- a/packages/canvas-tokens/utils/formatters/index.ts
+++ b/packages/canvas-tokens/utils/formatters/index.ts
@@ -5,6 +5,7 @@ import {
   formatCommonToObjects,
   formatES6Exports,
   formatCommonJSExports,
+  formatES6ToTypes,
 } from './formatJS';
 import {formatCSSComposite, formatLessComposite, formatSassComposite} from './formatStyles';
 import {mergeObjects} from './mergeObjects';
@@ -18,6 +19,9 @@ export const formats: Record<string, Formatter> = {
   // formatter creating the es6 file structure
   // with tokens united in objects
   'es6/objects': formatES6ToObjects,
+  // formatter creating the es6 and common-js types including the `as const`
+  'es6/types': formatES6ToTypes,
+  'common-js/types': formatES6ToTypes,
   // formatter creating the common-js file structure
   // with tokens united in objects
   'common-js/objects': formatCommonToObjects,

--- a/packages/canvas-tokens/utils/spec/formats.spec.ts
+++ b/packages/canvas-tokens/utils/spec/formats.spec.ts
@@ -347,6 +347,58 @@ describe('formats', () => {
     });
   });
 
+  describe('es6/types', () => {
+    it('should return correct file structure for es6', () => {
+      const result = formats['es6/types']({
+        ...defaultArgs,
+        options: {
+          formats: ['javascript/es6'],
+          level: 'sys',
+        },
+        dictionary: {
+          properties: {
+            opacity: {
+              disabled: '--cnvs-base-opacity-300',
+            },
+          },
+        },
+      });
+
+      const expected =
+        headerContent +
+        'export declare const opacity = {\n  "disabled": "--cnvs-base-opacity-300"\n} as const;' +
+        '\n';
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('common-js/types', () => {
+    it('should return correct file structure for es6', () => {
+      const result = formats['es6/types']({
+        ...defaultArgs,
+        options: {
+          formats: ['javascript/common-js'],
+          level: 'sys',
+        },
+        dictionary: {
+          properties: {
+            opacity: {
+              disabled: '--cnvs-base-opacity-300',
+            },
+          },
+        },
+      });
+
+      const expected =
+        headerContent +
+        'export declare const opacity = {\n  "disabled": "--cnvs-base-opacity-300"\n} as const;' +
+        '\n';
+
+      expect(result).toBe(expected);
+    });
+  });
+
   describe('merge/refs', () => {
     it('should return correct file structure for es6', () => {
       const result = formats['merge/refs']({

--- a/packages/canvas-tokens/utils/spec/formats.spec.ts
+++ b/packages/canvas-tokens/utils/spec/formats.spec.ts
@@ -367,7 +367,7 @@ describe('formats', () => {
       const expected =
         headerContent +
         'export declare const opacity = {\n  "disabled": "--cnvs-base-opacity-300"\n} as const;' +
-        '\n';
+        '\n\n';
 
       expect(result).toBe(expected);
     });
@@ -393,7 +393,7 @@ describe('formats', () => {
       const expected =
         headerContent +
         'export declare const opacity = {\n  "disabled": "--cnvs-base-opacity-300"\n} as const;' +
-        '\n';
+        '\n\n';
 
       expect(result).toBe(expected);
     });


### PR DESCRIPTION
## Issue

#41

## Overview

Adds the `as const` to type definition files

## Where Should the Reviewer Start?

Always start with specs

## Testing Manually

Run `npm run build:tokens`
