### PR TITLE
fix: Fix JS Doc comment and value order

### DIFF
--- a/packages/canvas-tokens/utils/formatters/formatTypes.ts
+++ b/packages/canvas-tokens/utils/formatters/formatTypes.ts
@@ -98,14 +98,20 @@ const recursivelyCreateFileStructure = ({
 const generateJSDoc = (original: TransformedToken, depth: number) => {
   const spaces = '  '.repeat(depth);
   const extraSpaces = spaces + ' ';
+  const newJSDocLineStart = `\n${extraSpaces}* `;
   const {value, comment} = original;
   const pxValue = value.includes('rem') ? parseFloat(value) * 16 : null;
 
   const valueText = value + (pxValue ? ` (${pxValue}px)` : '');
-  const updatedComment = comment?.replace(/; /g, `\n${extraSpaces}* `);
+  const updatedComment = comment?.replace(/; /g, newJSDocLineStart);
   const text = comment
-    ? `${valueText}\n${extraSpaces}* \n${extraSpaces}* ${updatedComment}\n${extraSpaces}`
-    : valueText;
+    ? newJSDocLineStart +
+      valueText +
+      newJSDocLineStart +
+      newJSDocLineStart +
+      updatedComment +
+      `\n${extraSpaces}`
+    : ` ${valueText} `;
 
   return `${spaces}/**${text}*/\n`;
 };

--- a/packages/canvas-tokens/utils/formatters/formatTypes.ts
+++ b/packages/canvas-tokens/utils/formatters/formatTypes.ts
@@ -1,4 +1,4 @@
-import {Formatter, formatHelpers} from 'style-dictionary';
+import {Formatter, TransformedToken, formatHelpers} from 'style-dictionary';
 
 /**
  * Style Dictionary format function that creates token type definitions with JSDoc.
@@ -56,19 +56,10 @@ const recursivelyCreateFileStructure = ({
   entries.forEach(([key, values]) => {
     const original = originalValues[key];
     const spaces = '  '.repeat(depth);
-    const extraSpaces = spaces + ' ';
 
     if (typeof values === 'string') {
-      const pxVal = original.value.includes('rem') ? parseFloat(original.value) * 16 : null;
-      const hasComment = original.comment;
-      const commentParts = hasComment ? original.comment.split('; ') : [];
-      const commentText = hasComment
-        ? `\n${extraSpaces}* ${commentParts.join(`\n${extraSpaces}* `)}\n${extraSpaces}*`
-        : '';
-      const valueText = ` ${original.value}${pxVal ? ` (${pxVal}px)` : ''} `;
-      const jsDocText = `${spaces}/**${commentText}${valueText}${
-        original.comment ? '\n' + extraSpaces : ''
-      }*/\n`;
+      const jsDocText = generateJSDoc(original, depth);
+
       const innerText = depth
         ? `${spaces}"${key}": "${values}",`
         : `${startingText} ${key} = "${values}" ${endingText}`;
@@ -96,4 +87,25 @@ const recursivelyCreateFileStructure = ({
       replaceInContent,
     });
   });
+};
+
+/**
+ * Utility function to generate JS Doc with value and comment
+ * @param {Object} original - Style Dictionary token.
+ * @param {number} depth - Value of iteration to generate side spaces.
+ * @returns JS Doc content as a string
+ */
+const generateJSDoc = (original: TransformedToken, depth: number) => {
+  const spaces = '  '.repeat(depth);
+  const extraSpaces = spaces + ' ';
+  const {value, comment} = original;
+  const pxValue = value.includes('rem') ? parseFloat(value) * 16 : null;
+
+  const valueText = value + (pxValue ? ` (${pxValue}px)` : '');
+  const updatedComment = comment?.replace(/; /g, `\n${extraSpaces}* `);
+  const text = comment
+    ? `${valueText}\n${extraSpaces}* \n${extraSpaces}* ${updatedComment}\n${extraSpaces}`
+    : valueText;
+
+  return `${spaces}/**${text}*/\n`;
 };

--- a/packages/canvas-tokens/utils/spec/formats.spec.ts
+++ b/packages/canvas-tokens/utils/spec/formats.spec.ts
@@ -372,9 +372,9 @@ describe('formats', () => {
 
       const expected =
         headerContent +
-        'export declare const opacity = {\n  /**\n   * Test JSDoc\n   * 0.4 \n   */\n  "disabled": "--cnvs-base-opacity-300",\n} as const;\n';
+        'export declare const opacity = {\n  /**\n   * 0.4\n   * \n   * Test JSDoc\n   */\n  "disabled": "--cnvs-base-opacity-300",\n} as const;\n';
 
-      expect(result).toBe(expected); //?
+      expect(result).toBe(expected);
     });
 
     it('should have one line jsDoc for tokens without comment', () => {


### PR DESCRIPTION
## Issue

Fixes #61 

## Summary

Changed the order for value and comment in JS Doc making value appearing the first

## Release Category

<!-- Documentation, Infrastructure, Tokens -->
Web Documentation