### PR TITLE
chore: Update build and release scripts

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -23,13 +23,13 @@ jobs:
       
       - name: Build Tokens
         shell: bash
-        run: yarn build:tokens --no-cache
+        run: yarn build:tokens
 
       # Build Storybook and extract component stories for Storybook aggregation. This will be used
       # for Chromatic rebaselining and publishing to GH Pages.
       - name: Build Storybook
         shell: bash
-        run: yarn build-storybook --no-cache
+        run: yarn build-storybook
 
       - name: Publish Storybook
         uses: JamesIves/github-pages-deploy-action@v4.4.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,10 +25,10 @@ jobs:
           node_version: 18.x
 
       - name: Build Tokens
-        run: yarn build:tokens --no-cache
+        run: yarn build:tokens
 
       - name: Build Storybook
-        run: yarn build-storybook --no-cache
+        run: yarn build-storybook
 
       - name: Cache Build
         id: build-cache
@@ -54,7 +54,7 @@ jobs:
         run: yarn lint
 
       - name: Build Tokens
-        run: yarn build:tokens --no-cache
+        run: yarn build:tokens
 
       - name: Type Check
         shell: bash

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -101,3 +101,10 @@ yarn test
 We use [Chromatic](https://www.chromatic.com/builds?appId=64fb84ee156f858ef9126097) for visual regression tests. Chromatic runs automatically on every pull request and requires changes to be verified before merging. When branch is merged to `main`, the baseline is updated.
 
 ## Publishing
+
+Publishing is currently a manual process. But it's relatively straightforward.
+
+1. Run the [Web Release GitHub Action workflow](https://github.com/Workday/canvas-tokens/actions/workflows/release-web.yml) and choose your version override: `patch`, `minor`, or `major`.
+2. Once the action is complete, pull down the latest `main` locally.
+3. Run `yarn release` to publish to npm
+   a. You'll need a npm token to publish

--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e", "build-storybook"]
+        "cacheableOperations": ["lint", "test", "e2e"]
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "scripts": {
     "commit": "git-cz",
-    "build:tokens": "yarn clean:tokens && npx nx build @workday/canvas-tokens",
-    "clean:tokens": "npx nx clean @workday/canvas-tokens-web",
+    "build:tokens": "nx build @workday/canvas-tokens",
+    "clean:tokens": "nx clean @workday/canvas-tokens-web",
     "lint": "eslint -c ./.eslintrc.js --ext=ts .",
     "precommit": "lint-staged",
     "prepare": "husky install",
@@ -23,7 +23,8 @@
     "test": "jest -c jest.config.ts",
     "tokens-config": "ts-node scripts/tokens-config",
     "typecheck": "tsc -p . --noEmit",
-    "release": "yarn build:tokens --cache=false && changeset publish --tags latest"
+    "prerelease": "yarn clean:tokens && yarn build:tokens",
+    "release": "changeset publish --tags latest"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
@@ -57,7 +58,7 @@
     "react-dom": "^18.2.0",
     "rimraf": "^5.0.5",
     "ts-jest": "^29.1.0",
-    "ts-node": "10.9.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5.0.4",
     "vite": "~4.3.9"
   },

--- a/packages/canvas-tokens-web/package.json
+++ b/packages/canvas-tokens-web/package.json
@@ -9,7 +9,7 @@
   "sideEffects": false,
   "types": "dist/es6/index.d.ts",
   "scripts": {
-    "clean": "rimraf dist"
+    "clean": "rimraf dist css less scss"
   },
   "files": [
     "dist/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10081,6 +10081,25 @@ ts-node@10.9.1, ts-node@^10.8.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tsconfig-paths@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz#ef78e19039133446d244beac0fd6a1632e2d107c"


### PR DESCRIPTION
## Issue

Resolves #71

## Summary

The `build` script issues were caused by `nx`, so we're disabling cacheing for all `build` and `build-storybook` actions. They should work consistently now. I also updated the `clean:tokens` script to remove other built directories. 

## Release Category

Infrastructure
