### PR TITLE
chore: Sync Tokens Studio config 🤖

### DIFF
--- a/packages/canvas-tokens/tokens/base.json
+++ b/packages/canvas-tokens/tokens/base.json
@@ -345,7 +345,7 @@
           "type": "color"
         },
         "200": {
-          "value": "#c3c2ff",
+          "value": "#c2cfff",
           "type": "color"
         },
         "300": {
@@ -449,7 +449,7 @@
           "type": "color"
         },
         "200": {
-          "value": "#ffbdbd",
+          "value": "#ffbdd6",
           "type": "color"
         },
         "300": {
@@ -718,11 +718,11 @@
         "type": "number"
       },
       "400": {
-        "value": "0.65",
+        "value": "0.64",
         "type": "number"
       },
       "500": {
-        "value": "0.85",
+        "value": "0.84",
         "type": "number"
       }
     },


### PR DESCRIPTION
## Issue

Fixes #90

## Summary

This PR corrects the following base tokens:
- berry smoothie 200
- pomegranate 200
- opacity 400
- opacity 500

## Release Category

Tokens

### Release Note
A few incorrect values has been fixed: `berrySmothie200` became `#c2cfff`, `pomegranate200` became `#ffbdd6, `opacity400` became `0.64`, `opacity500` became `0.84`.