### PR TITLE
chore: Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -14,7 +14,7 @@ jobs:
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: prerelease/major # checkout the next branch
@@ -44,7 +44,7 @@ jobs:
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0 # Needed to do merges

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Used for conventional commit ranges
       

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
@@ -18,7 +18,7 @@ jobs:
     needs: 'install'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
@@ -42,7 +42,7 @@ jobs:
     needs: ['install', 'build']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
@@ -69,7 +69,7 @@ jobs:
     needs: 'build'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required to retrieve git history
 

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -21,7 +21,7 @@ jobs:
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0 # Used for conventional commit ranges
@@ -111,7 +111,7 @@ jobs:
   #     ## First, we'll checkout the repository. We don't persist credentials because we need a
   #     ## Personal Access Token to push on a branch that is protected. See
   #     ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #       with:
   #         persist-credentials: false
   #         fetch-depth: 0 # Used for conventional commit ranges

--- a/.github/workflows/tokens-studio-sync.yml
+++ b/.github/workflows/tokens-studio-sync.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Used for conventional commit ranges
 
@@ -29,7 +29,11 @@ jobs:
       - name: Sync Tokens
         shell: bash
         run: yarn tokens-config sync ${{ inputs.token_type }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Create Sync PR
         shell: bash
         run: yarn tokens-config create-pull
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issue

## Summary

Bumping `actions/checkout` to v4 as v3 uses Node 16 and is deprecated.

## Release Category

Infrastructure

---

<!-- For the reviewer -->

## Where Should the Reviewer Start?

<!-- `packages/canvas-tokens/index.ts` -->

## Testing Manually

<!-- List steps to test this locally. -->

## Thank You GIF

<!-- _Share a fun [gif](https://giphy.com) to say thanks to your reviewer:_ -->

<!-- ![](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
