### PR TITLE
chore: Sync Tokens Studio config 🤖

### DIFF
--- a/packages/canvas-tokens/tokens/web/brand.json
+++ b/packages/canvas-tokens/tokens/web/brand.json
@@ -130,6 +130,38 @@
         "type": "color"
       }
     },
+    "action": {
+      "lightest": {
+        "value": "{brand.primary.lightest}",
+        "type": "color",
+        "description": "Lightest action color"
+      },
+      "light": {
+        "value": "{brand.primary.light}",
+        "type": "color",
+        "description": "Light action color"
+      },
+      "base": {
+        "value": "{brand.primary.base}",
+        "type": "color",
+        "description": "Base action color"
+      },
+      "dark": {
+        "value": "{brand.primary.dark}",
+        "type": "color",
+        "description": "Dark action color"
+      },
+      "darkest": {
+        "value": "{brand.primary.darkest}",
+        "type": "color",
+        "description": "Darkest action color"
+      },
+      "accent": {
+        "value": "{brand.primary.accent}",
+        "type": "color",
+        "description": "Foreground color in actions"
+      }
+    },
     "common": {
       "focus-outline": {
         "value": "{palette.blueberry.400}",


### PR DESCRIPTION
## Issue
Fixes: https://github.com/Workday/canvas-tokens/issues/130
<!-- Add an issue number and link the PR with a keyword: "Fixes", "Resolves", or "Closes" -->
<!-- Resolves #123 -->

## Summary
Add new brand action tokens to better support theming customization of actions.
 
<!-- Give a brief description of what this PR does. -->

## Release Category

Web Tokens

### Release Note

We've added new `action` tokens to brand. While these tokens are available, limit their use and in most cases the default brand tokens should be used for theming.

- `brand.action.lightest`
- `brand.action.light`
- `brand.action.base`
- `brand.action.dark`
- `brand.action.darkest`
- `brand.action.accent`

---
