### PR TITLE
chore: Update release action to use OpenID Connect

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
           'The version override: patch, minor or major'
         required: false
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
 jobs:
   release:
     # Only run if:
@@ -82,8 +85,6 @@ jobs:
 
       - uses: Workday/canvas-kit-actions/do-release@v1
         if: ${{ steps.set_version.outputs.version }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_CI_PUBLISH_TOKEN }}
         id: release
         with:
           ghToken: ${{ secrets.GH_RW_TOKEN }}


### PR DESCRIPTION
## Issue

Resolves #222

## Summary

We're moving from using an npm auth token to a Trusted Provider with OpenID Connect, per [GitHub and npm's guidance](https://github.blog/security/supply-chain-security/our-plan-for-a-more-secure-npm-supply-chain/).

## Release Category

Infrastructure

---

<!-- For the reviewer -->

## Where Should the Reviewer Start?

`.github/workflows/release.yml`

## Testing Manually

The only way to test is with a release, I think.

## Thank You GIF

![a corgi loaf rocket](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExM3B0ZTBobmhnZzBtbzdhdW80NnEzdGd1aW16cDYwbTBtY252bDI5cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/KY3VnTOONvgxllVac0/giphy.gif)
