### PR TITLE
chore: Disable CSS minification in Storybook

### DIFF
--- a/packages/canvas-tokens-docs/.storybook/main.ts
+++ b/packages/canvas-tokens-docs/.storybook/main.ts
@@ -27,7 +27,9 @@ const config: StorybookConfig = {
   viteFinal: async config =>
     mergeConfig(config, {
       plugins: [nxViteTsPaths()],
-      cssMinify: false,
+      build: {
+        cssMinify: false,
+      },
     }),
 };
 


### PR DESCRIPTION
## Issue

Disables CSS minification in Storybook. 


## Summary

We had it in place as of last week but not within a build object in the config like Vite requires. We need this in palce as having CSS minification enabled makes our duration base tokens get converted to "s" instead of "ms".

## Release Category
Documentation


---

<!-- For the reviewer -->

## Where Should the Reviewer Start?
Check the `main.ts` (storybook config)

## Testing Manually

`yarn build:tokens`
`yarn build-storybook`
`npx serve docs/storybook/@workday/canvas-tokens-docs -p 5000` 

Make sure the duration tokens table shows `ms` for all tokens.

