### PR TITLE
docs: Add missing `size.sm` to Deprecated Space Tokens in v4UpgradeGuideStories.mdx

### DIFF
--- a/packages/canvas-tokens-docs/stories/migration/v4UpgradeGuide.stories.mdx
+++ b/packages/canvas-tokens-docs/stories/migration/v4UpgradeGuide.stories.mdx
@@ -451,7 +451,7 @@ on the context of how it's used. In general you should:
 | `system.space.x4`   | 16px       | `padding.md`   | `gap.md`   | `size.xxxs` |                                                |
 | `system.space.x5`   | 20px       | `padding.lg`   | —          | `size.xxs`  |                                                |
 | `system.space.x6`   | 24px       | `padding.xl`   | `gap.lg`   | `size.xs`   |                                                |
-| `system.space.x8`   | 32px       | `padding.xxl`  | `gap.xl`   |             |                                                |
+| `system.space.x8`   | 32px       | `padding.xxl`  | `gap.xl`   | `size.sm`   |                                                |
 | `system.space.x10`  | 40px       | —              | —          | `size.md`   |                                                |
 | `system.space.x14`  | 56px       | —              | —          | `size.xl`   |                                                |
 | `system.space.x16`  | 64px       | —              | `gap.xxl`  | `size.xxl`  |                                                |


### PR DESCRIPTION
## Summary

Adds missing `system.space.x8` -> `size.sm` (both are 32px) to Deprecated Space Tokens in v4UpgradeGuideStories.mdx

This is my first canvas-tokens PR - let me know if I should create an issue first or if there's anything else I should change. Thanks!