### PR TITLE
chore: Update deprecated GH Actions

### DIFF
--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -11,6 +11,6 @@ jobs:
 
     steps:
       - name: Enable Automerge
-        uses: Workday/canvas-kit-actions/enable-automerge@v1
+        uses: Workday/canvas-kit-actions/enable-automerge@v2
         with:
           token: ${{ secrets.GH_RW_TOKEN }}

--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Cache Build
         id: build-cache
-        uses: actions/cache/@v2
+        uses: actions/cache@v5
         with:
           path: docs
           key: ${{ runner.os }}-build-${{ github.sha }}

--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Needed to do merges
 
-      - uses: Workday/canvas-kit-actions/install@v1
+      - uses: Workday/canvas-kit-actions/install@v2
         with:
           node_version: 24.x
 

--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
-          node_version: 18.x
+          node_version: 24.x
 
       ## A `yarn bump` will create a commit and a tag. We need to set up the git user to do this.
       ## We'll make that user be the github-actions user.

--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -14,7 +14,7 @@ jobs:
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           ref: prerelease/major # checkout the next branch
@@ -44,7 +44,7 @@ jobs:
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0 # Needed to do merges

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Used for conventional commit ranges
       

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -19,7 +19,7 @@ jobs:
         run: yarn install
       # - uses: Workday/canvas-kit-actions/install@v1
       #   with:
-      #     node_version: 18.x
+      #     node_version: 24.x
       
       - name: Build Tokens
         shell: bash

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install
         shell: bash
         run: yarn install
-      # - uses: Workday/canvas-kit-actions/install@v1
+      # - uses: Workday/canvas-kit-actions/install@v2
       #   with:
       #     node_version: 24.x
       

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
@@ -18,7 +18,7 @@ jobs:
     needs: 'install'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
@@ -42,7 +42,7 @@ jobs:
     needs: ['install', 'build']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
@@ -75,7 +75,7 @@ jobs:
     needs: 'build'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required to retrieve git history
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Workday/canvas-kit-actions/install@v1
+      - uses: Workday/canvas-kit-actions/install@v2
         with:
           node_version: 24.x
 
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Workday/canvas-kit-actions/install@v1
+      - uses: Workday/canvas-kit-actions/install@v2
         with:
           node_version: 24.x
 
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Workday/canvas-kit-actions/install@v1
+      - uses: Workday/canvas-kit-actions/install@v2
         with:
           node_version: 24.x
       
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0 # Required to retrieve git history
 
-      - uses: Workday/canvas-kit-actions/install@v1
+      - uses: Workday/canvas-kit-actions/install@v2
         with:
           node_version: 24.x
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Cache Build
         id: build-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: docs
           key: ${{ runner.os }}-build-${{ github.sha }}
@@ -84,7 +84,7 @@ jobs:
           node_version: 22.x
 
       - name: Restore Build
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: docs
           key: ${{ runner.os }}-build-${{ github.sha }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
-          node_version: 22.x
+          node_version: 24.x
 
   build:
     runs-on: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
-          node_version: 22.x
+          node_version: 24.x
 
       - name: Build Tokens
         run: yarn build:tokens
@@ -46,7 +46,7 @@ jobs:
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
-          node_version: 22.x
+          node_version: 24.x
       
       # Keep steps separate for Github Actions annotation matching: https://github.com/actions/setup-node/blob/83c9f7a7df54d6b57455f7c57ac414f2ae5fb8de/src/setup-node.ts#L26-L33
       - name: Lint
@@ -81,7 +81,7 @@ jobs:
 
       - uses: Workday/canvas-kit-actions/install@v1
         with:
-          node_version: 22.x
+          node_version: 24.x
 
       - name: Restore Build
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           node-version: 24.x
           # Do NOT set registry-url - it creates token-based auth that conflicts with OIDC
       
-      - uses: Workday/canvas-kit-actions/install@v1
+      - uses: Workday/canvas-kit-actions/install@v2
         with:
           node_version: 24.x
       
@@ -95,7 +95,7 @@ jobs:
             echo "preid=beta" >> "$GITHUB_OUTPUT"
           fi
       
-      - uses: Workday/canvas-kit-actions/do-release@v1
+      - uses: Workday/canvas-kit-actions/do-release@v2
         if: ${{ steps.set_version.outputs.version }}
         id: release
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,14 +39,14 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # Used for conventional commit ranges
       
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           # Do NOT set registry-url - it creates token-based auth that conflicts with OIDC
       
       - uses: Workday/canvas-kit-actions/install@v1
         with:
-          node_version: 22.x
+          node_version: 24.x
       
       # Upgrade npm to 11.5.1+ for OIDC support (Node.js 22.x comes with npm 10.x)
       - name: Upgrade npm for OIDC support

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           # Do NOT set registry-url - it creates token-based auth that conflicts with OIDC
       
       - uses: Workday/canvas-kit-actions/install@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0 # Used for conventional commit ranges


### PR DESCRIPTION
## Issue

Resolves #315

## Summary

This PR updates deprecated GH Actions that run on Node 20 and will be removed on June 16th. This also bumps us up to use Node 24.

1. Updates actions/setup-node from v4 to v6 and Node 24 ([see docs](https://github.com/actions/checkout#checkout-v6))
2. Updates actions/checkout from v4 to v6 ([see docs](https://github.com/actions/checkout#checkout-v6))
3. Updates actions/cache from v3 and v4 to v5 ([see docs](https://github.com/actions/checkout#checkout-v6))


## Release Category

Infrastructure

---

<!-- For the reviewer -->

## Where Should the Reviewer Start?

<!-- `packages/canvas-tokens/index.ts` -->

## Testing Manually

<!-- List steps to test this locally. -->

## Thank You GIF

<!-- _Share a fun [gif](https://giphy.com) to say thanks to your reviewer:_ -->

<!-- ![](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
